### PR TITLE
Fix gateway integration test timeouts

### DIFF
--- a/packages/gateway/tests/helpers/testUtils.ts
+++ b/packages/gateway/tests/helpers/testUtils.ts
@@ -59,7 +59,7 @@ export function waitForWebSocketOpen(ws: WebSocket): Promise<void> {
 
     const timeout = setTimeout(() => {
       reject(new Error('WebSocket connection timeout'));
-    }, 5000);
+    }, 8000); // Increased from 5000 to 8000
 
     ws.once('open', () => {
       clearTimeout(timeout);
@@ -78,7 +78,7 @@ export function waitForWebSocketMessage(ws: WebSocket): Promise<any> {
   return new Promise((resolve, reject) => {
     const timeout = setTimeout(() => {
       reject(new Error('WebSocket message timeout'));
-    }, 5000);
+    }, 8000); // Increased from 5000 to 8000
 
     ws.once('message', (data) => {
       clearTimeout(timeout);
@@ -102,7 +102,7 @@ export function waitForWelcomeMessage(ws: WebSocket): Promise<any> {
   return new Promise((resolve, reject) => {
     const timeout = setTimeout(() => {
       reject(new Error('Welcome message timeout'));
-    }, 5000);
+    }, 8000); // Increased from 5000 to 8000
 
     const messageHandler = (data: any) => {
       try {

--- a/packages/gateway/tests/integration/server.integration.test.ts
+++ b/packages/gateway/tests/integration/server.integration.test.ts
@@ -204,7 +204,7 @@ describe('MCPx Server Integration Tests', () => {
       expect(welcomeMessage.payload.type).toBe('welcome');
 
       ws.close();
-    });
+    }, 10000); // Increase timeout to 10 seconds
 
     it('should reject WebSocket connection without token', async () => {
       const wsUrl = `ws://localhost:${port}/v0/ws?topic=integration-test`;
@@ -302,7 +302,7 @@ describe('MCPx Server Integration Tests', () => {
 
       ws1.close();
       ws2.close();
-    });
+    }, 10000); // Increase timeout to 10 seconds
   });
 
   describe('End-to-End Message Flow', () => {


### PR DESCRIPTION
## Summary
- Fixes flaky gateway integration tests that were timing out
- Tests were failing both locally and in CI

## Problem
The WebSocket integration tests had a race condition where:
- Test timeout was set to 5000ms
- Helper functions also had 5000ms timeouts
- Tests would timeout before helpers could properly report what went wrong

## Solution
- Increased test timeouts to 10 seconds for WebSocket tests
- Increased helper function timeouts to 8 seconds
- This ensures helper functions can complete and provide proper error messages before test timeout

## Test Results
✅ All 69 tests now pass
✅ Previously failing tests:
  - `should establish WebSocket connection with valid token`
  - `should handle multiple participants in same topic`

🤖 Generated with [Claude Code](https://claude.ai/code)